### PR TITLE
Add support for managing interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,8 @@ Usage:
     $collection->add(2); // Throw exception
     $collection->add(new \stdClass()); // works
 
+    $collection = new TypedCollection('\Countable');
+    $collection->add(2); // Throw exception
+    $collection->add(new ClassThatImplementsCountable()); // works
+
 Note: This class can be used in conjunction with [doctrine/collections](https://github.com/doctrine/collections) as an added functionality.

--- a/lib/Star/Component/Collection/TypedCollection.php
+++ b/lib/Star/Component/Collection/TypedCollection.php
@@ -42,7 +42,9 @@ class TypedCollection implements Collection, Selectable
     public function __construct($type, array $elements = array())
     {
         if (false === class_exists($type)) {
-            throw new InvalidArgumentException("The class '{$type}' must exists.");
+            if (false === interface_exists($type)) {
+                throw new InvalidArgumentException("The class/interface '{$type}' must exists.");
+            }
         }
 
         $this->type = $type;

--- a/tests/Star/Component/Collection/TypedCollectionTest.php
+++ b/tests/Star/Component/Collection/TypedCollectionTest.php
@@ -410,10 +410,17 @@ class TypedCollectionTest extends StarCollectionTestCase
 
     /**
      * @expectedException        \Star\Component\Collection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The class 'qwewq' must exists.
+     * @expectedExceptionMessage The class/interface 'qwewq' must exists.
      */
     public function testShouldThrowExceptionWhenClassDoNotExists()
     {
         new TypedCollection('qwewq');
+    }
+
+    public function testShouldSupportInterface()
+    {
+        $this->collection = new TypedCollection('\Countable');
+        $this->collection->add($this->getMock('\Countable'));
+        $this->assertCount(1, $this->collection);
     }
 }


### PR DESCRIPTION
Interface could not be passed as supported class for the TypedCollection (Reopen #12 )
