### PR TITLE
Add TypedCollection::getType() and create method

### DIFF
--- a/tests/Star/Component/Collection/TypedCollectionTest.php
+++ b/tests/Star/Component/Collection/TypedCollectionTest.php
@@ -423,4 +423,42 @@ class TypedCollectionTest extends StarCollectionTestCase
         $this->collection->add($this->getMock('\Countable'));
         $this->assertCount(1, $this->collection);
     }
+
+    /**
+     * @depends testShouldAddTheSupportedObject
+     *
+     * @expectedException        \RuntimeException
+     * @expectedExceptionMessage The type should be defined.
+     */
+    public function testShouldThrowExceptionWhenTypeNotConfigured()
+    {
+        new TypedCollection();
+    }
+
+    public function testShouldEnableEasyExtension()
+    {
+        $this->collection = new GetTypeDefinitionCollection();
+        $this->collection->add(new \stdClass());
+        $this->assertCount(1, $this->collection);
+    }
+
+    public function testShouldAddElements()
+    {
+        $elements = array(
+            new \stdClass(),
+            new \stdClass(),
+        );
+
+        $this->assertCount(0, $this->collection);
+        $this->collection->addElements($elements);
+        $this->assertCount(2, $this->collection);
+    }
+}
+
+class GetTypeDefinitionCollection extends TypedCollection
+{
+    protected function getType()
+    {
+        return '\stdClass';
+    }
 }


### PR DESCRIPTION
Add the option to configure the type without parameters.

```
// will thow exception
$collection = new TypedCollection(); 

// Works
class SomeCollection extends TypedCollection
{
    protected function getType()
    {
         return '\stdClass';
    }
}
$collection = new SomeCollection();

// Dependencies
class SomeDepsCollection extends TypedCollection
{
    private $newDep;

    protected function __construct($newDep)
    {
         $this->deps = $deps;
         parent::__construct();
    }

    protected function getType()
    {
         return '\stdClass';
    }

    protected function create($elements)
    {
         $newCollection = new self($this->type);
         $newCollection->addElements($elements);

         return $collection;
    }
}
```

Todo see if the match, partition ... works
