### PR TITLE
Fix #24 - Add a mapped item return anything else than Class

### DIFF
--- a/lib/Star/Component/Collection/IdentityCollection.php
+++ b/lib/Star/Component/Collection/IdentityCollection.php
@@ -8,6 +8,7 @@
 namespace Star\Component\Collection;
 
 use Closure;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Star\Component\Collection\Exception\DuplicatedIdentityException;
 use Star\Component\Collection\UniqueId\UniqueId;
@@ -311,11 +312,11 @@ class IdentityCollection implements Collection
      *
      * @param Closure $func
      *
-     * @return Collection
+     * @return Collection The returned collection is not typed anymore, since the values may not be of the class type.
      */
     public function map(Closure $func)
     {
-        return new static($this->type, $this->elements->map($func)->toArray());
+        return new ArrayCollection($this->elements->map($func)->getValues());
     }
 
     /**

--- a/lib/Star/Component/Collection/TypedCollection.php
+++ b/lib/Star/Component/Collection/TypedCollection.php
@@ -346,22 +346,13 @@ class TypedCollection implements Collection, Selectable
      *
      * @param Closure $func
      *
-     * @return Collection
+     * @return Collection The returned collection is not typed anymore, since the values may not be of the class type.
      */
     public function map(Closure $func)
     {
         $this->guardAgainstInvalidGivenType();
-        $elements = $this->collection->map($func)->toArray();
-        $newCollection = $this->create();
-        foreach ($elements as $key => $element) {
-            try {
-                $newCollection->set($key, $element);
-            } catch (InvalidArgumentException $e) {
-                // do nothing, because the mapped item is not instance of type
-            }
-        }
 
-        return $newCollection;
+        return new ArrayCollection($this->collection->map($func)->getValues());
     }
 
     /**

--- a/tests/Star/Component/Collection/IdentityCollectionTest.php
+++ b/tests/Star/Component/Collection/IdentityCollectionTest.php
@@ -298,13 +298,17 @@ final class IdentityCollectionTest extends \PHPUnit_Framework_TestCase
         $this->collection->add($this->identity2);
         $this->collection->add($this->identity3);
 
-        $expected = array($this->identity2);
+        $expected = array(
+            0 => false,
+            1 => true,
+            2 => false,
+        );
         $closure = function (UniqueIdentity $element) {
-            if ($element->uid()->id() == 2) return $element;
+            return $element->uid()->id() == 2;
         };
         $newCollection = $this->collection->map($closure);
-        $this->assertInstanceOf(IdentityCollection::CLASS_NAME, $newCollection);
-        $this->assertSame($expected, $newCollection->toArray());
+        $this->assertInstanceOf('Doctrine\Common\Collections\Collection', $newCollection);
+        $this->assertEquals($expected, $newCollection->toArray());
     }
 
     public function test_should_partition_the_collection_in_two()

--- a/tests/Star/Component/Collection/TypedCollectionTest.php
+++ b/tests/Star/Component/Collection/TypedCollectionTest.php
@@ -382,13 +382,17 @@ class TypedCollectionTest extends StarCollectionTestCase
         $this->collection->add($second = (object) array('id' => 1));
         $this->collection->add($third = new \stdClass());
 
-        $expected = array(1 => $second);
+        $expected = array(
+            0 => null,
+            1 => $second,
+            2 => null,
+        );
         $closure = function ($element) {
             if (isset($element->id)) return $element;
         };
         $newCollection = $this->collection->map($closure);
-        $this->assertInstanceOf(self::COLLECTION_TYPE, $newCollection);
-        $this->assertSame($expected, $newCollection->toArray());
+        $this->assertInstanceOf('Doctrine\Common\Collections\Collection', $newCollection);
+        $this->assertEquals($expected, $newCollection->toArray());
         $this->assertCount(3, $this->collection);
         $this->assertContainsOnlyInstancesOf('stdClass', $this->collection);
     }
@@ -483,13 +487,17 @@ class TypedCollectionTest extends StarCollectionTestCase
             $third = new \stdClass(),
         ));
 
-        $expected = array(1 => $second);
+        $expected = array(
+            0 => null,
+            1 => $second,
+            2 => null,
+        );
         $closure = function ($element) {
             if (isset($element->id)) return $element;
         };
         $newCollection = $this->collection->map($closure);
-        $this->assertInstanceOf(__NAMESPACE__ . '\ExtendedStubCollection', $newCollection);
-        $this->assertSame($expected, $newCollection->toArray());
+        $this->assertInstanceOf('Doctrine\Common\Collections\Collection', $newCollection);
+        $this->assertEquals($expected, $newCollection->toArray());
         $this->assertCount(3, $this->collection);
         $this->assertContainsOnlyInstancesOf('stdClass', $this->collection);
     }
@@ -810,6 +818,17 @@ class TypedCollectionTest extends StarCollectionTestCase
             'Star\Component\Collection\Exception\InvalidArgumentException',
             'The supported type should be given on construct.'
         );
+    }
+
+    public function test_it_should_throw_an_exception_when_mapping_with_wrong_type()
+    {
+        $collection = new TypedCollection('\stdClass', [new stdClass()]);
+        $new = $collection->map(function (stdClass $class) {
+            return 'not an stdClass';
+        });
+        $this->assertCount(1, $new);
+        $this->assertInstanceOf('Doctrine\Common\Collections\Collection', $new);
+        $this->assertSame('not an stdClass', $new[0]);
     }
 }
 


### PR DESCRIPTION
* Map functions now return a non-typed collection to allow a collection of anything to be returned